### PR TITLE
compatibility with latest logrus mate.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -10,8 +10,17 @@
 [[projects]]
   branch = "master"
   name = "github.com/go-akka/configuration"
-  packages = [".","hocon"]
+  packages = [
+    ".",
+    "hocon"
+  ]
   revision = "755180b9a146a94d76051113e9624bdc8327c499"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/gogap/config"
+  packages = ["."]
+  revision = "b113a10c50f639b23d8b4839b1d7bd0a36d12573"
 
 [[projects]]
   branch = "master"
@@ -22,7 +31,17 @@
 [[projects]]
   branch = "master"
   name = "github.com/hashicorp/hcl"
-  packages = [".","hcl/ast","hcl/parser","hcl/scanner","hcl/strconv","hcl/token","json/parser","json/scanner","json/token"]
+  packages = [
+    ".",
+    "hcl/ast",
+    "hcl/parser",
+    "hcl/scanner",
+    "hcl/strconv",
+    "hcl/token",
+    "json/parser",
+    "json/scanner",
+    "json/token"
+  ]
   revision = "23c074d0eceb2b8a5bfdbb271ab780cde70f05a8"
 
 [[projects]]
@@ -57,7 +76,10 @@
 
 [[projects]]
   name = "github.com/spf13/afero"
-  packages = [".","mem"]
+  packages = [
+    ".",
+    "mem"
+  ]
   revision = "8d919cbe7e2627e417f3e45c3c0e489a5b7e2536"
   version = "v1.0.0"
 
@@ -94,7 +116,14 @@
 [[projects]]
   branch = "master"
   name = "golang.org/x/text"
-  packages = ["internal/gen","internal/triegen","internal/ucd","transform","unicode/cldr","unicode/norm"]
+  packages = [
+    "internal/gen",
+    "internal/triegen",
+    "internal/ucd",
+    "transform",
+    "unicode/cldr",
+    "unicode/norm"
+  ]
   revision = "57961680700a5336d15015c8c50686ca5ba362a4"
 
 [[projects]]
@@ -106,6 +135,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "25d20defe186ab48996e970ac0a48a8dc91c004eedc67ad97a8bbdf353c85396"
+  inputs-digest = "a1e61e9caaf16b18e7058396a9e3a89a006ef620c97a3c42f2f21642c483cae4"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ Then, an example config (I use YAML, YMMV) could look like, e.g.:
         level: debug
         formatter:
           name: text
-        options:
-          force-colors: true
-          timestamp-format: "2006-01-02T15:04:05Z07:00"
-          disable-timestamp: false
-          full-timestamp: true
+          options:
+            force-colors: true
+            timestamp-format: "2006-01-02T15:04:05Z07:00"
+            disable-timestamp: false
+            full-timestamp: true
         hooks:
           # Let's say we want to set up an ELK hook
           logstash:

--- a/viper_mate.go
+++ b/viper_mate.go
@@ -223,7 +223,10 @@ func (cfg *provider) GetConfig(path string) config.Configuration {
 }
 
 func (cfg *provider) WithFallback(fallback config.Configuration) config.Configuration {
-	log.Panic("viperConfigProvider.WithFallback is not implemented")
+	if fallback == cfg {
+		return cfg
+	}
+	log.Panicf("viperConfigProvider.WithFallback is not implemented fallback: %#v // cfg:%#v)", fallback, cfg)
 	return nil
 }
 
@@ -279,6 +282,9 @@ func NewMate(cfg *viper.Viper) (*logrus_mate.LogrusMate, error) {
 	if cfg == nil {
 		return nil, errors.New("NewMate got a nil Viper reference")
 	}
+	// NOTE: Since https://github.com/gogap/config/commit/b113a10c50f639b23d8b4839b1d7bd0a36d12573
+	// we no longer actually need to set a fake ConfigString, because the configuration is always called with an
+	// empty string. Still keep it for now.
 	return logrus_mate.NewLogrusMate(
 		logrus_mate.ConfigString("/* viper */"), // Hack, see notes above
 		logrus_mate.ConfigProvider(&provider{V: cfg}),

--- a/viper_mate.go
+++ b/viper_mate.go
@@ -10,6 +10,8 @@ import (
 	"github.com/gogap/logrus_mate"
 	"github.com/spf13/cast"
 	"github.com/spf13/viper"
+	"github.com/gogap/config"
+	"fmt"
 )
 
 // provider is a Logrus Mate-compatible ConfigurationProvider
@@ -184,6 +186,14 @@ func (cfg *provider) GetStringList(path string) []string {
 	return nil
 }
 
+func (cfg *provider) IsEmpty() bool {
+	return len(cfg.V.AllKeys()) == 0
+}
+
+func (cfg *provider) String() string {
+	return fmt.Sprintf("%#v", cfg.V.AllSettings())
+}
+
 // Non-string list functions are not implemented in Viper
 func (cfg *provider) GetBooleanList(path string) []bool {
 	return []bool{}
@@ -204,7 +214,7 @@ func (cfg *provider) GetByteList(path string) []byte {
 	return []byte{}
 }
 
-func (cfg *provider) GetConfig(path string) logrus_mate.Configuration {
+func (cfg *provider) GetConfig(path string) config.Configuration {
 	sub := cfg.getSub(splitDottedPathHonouringQuotes(path))
 	if sub != nil {
 		return &provider{V: sub}
@@ -212,8 +222,9 @@ func (cfg *provider) GetConfig(path string) logrus_mate.Configuration {
 	return nil
 }
 
-func (cfg *provider) WithFallback(fallback logrus_mate.Configuration) {
+func (cfg *provider) WithFallback(fallback config.Configuration) config.Configuration {
 	log.Panic("viperConfigProvider.WithFallback is not implemented")
+	return nil
 }
 
 func (cfg *provider) HasPath(path string) bool {
@@ -254,11 +265,11 @@ func (cfg *provider) Keys() []string {
 // uses pre-provided Viper instance.
 // To not expose those dirty hacks to users we hide it in the NewViperMate
 
-func (cfg *provider) ParseString(cfgStr string) logrus_mate.Configuration {
+func (cfg *provider) ParseString(cfgStr string) config.Configuration {
 	return cfg
 }
 
-func (cfg *provider) LoadConfig(filename string) logrus_mate.Configuration {
+func (cfg *provider) LoadConfig(filename string) config.Configuration {
 	log.Panic("LoadConfig is not implemented and not supposed to be called")
 	return nil
 }


### PR DESCRIPTION
It seems there has been some refactoring in the latest logrus mate. This makes viper provider compatible with the latest master from https://github.com/gogap/logrus_mate/